### PR TITLE
Add fixed focus for PiCameraV3

### DIFF
--- a/software/python/robot/ppweb.py
+++ b/software/python/robot/ppweb.py
@@ -892,6 +892,10 @@ if __name__ == '__main__':
     )
     video_config["transform"] = libcamera.Transform(hflip=1, vflip=1)
     picam2.configure(video_config)
+    try:
+        picam2.set_controls({"AfMode": libcamera.controls.AfModeEnum.Manual, "LensPosition": 0.5}) #Set fixed focal length for Rpiv3 Camera (1/0.5 or 2m)
+    except:
+        log.info("Couldn't set Autofocus mode. Assuming PiCameraV2")
     stream_output = StreamingOutput()
 
     picam2.start_recording(JpegEncoder(), FileOutput(stream_output))


### PR DESCRIPTION
Changes:
- Set a fixed focal length of 2m on v3. 

The PiCameraV3 has far better low light performance but implements an auto focus routine that is bad for many of our use cases. This change allows it to mimic the v2 in terms of functionality for the Penguin Pi
